### PR TITLE
test: expand Shamir endomorphism checks

### DIFF
--- a/BitCrypto.Core/include/bitcrypto/endo_shamir.h
+++ b/BitCrypto.Core/include/bitcrypto/endo_shamir.h
@@ -73,7 +73,10 @@ static inline void split_scalar_lambda(const U256& k,U256& r1,U256& r2){
 
 // Shamir's trick: calcula a*P + b*G reutilizando MSM Pippenger
 static inline bool shamir_trick(const ECPointA& P,const U256& a,const U256& b,ECPointA& out){
-    if(P.infinity) { out = ECPointA{Fp::zero(),Fp::zero(),true}; return false; }
+    if(P.infinity || !Secp256k1::is_on_curve(P)){
+        out = ECPointA{Fp::zero(),Fp::zero(),true};
+        return false;
+    }
     std::vector<ECPointA> pts{P, Secp256k1::G()};
     std::vector<U256> sc{a, b};
     PippengerContext ctx; // utiliza precompute interno

--- a/BitCrypto.Core/include/bitcrypto/msm_pippenger.h
+++ b/BitCrypto.Core/include/bitcrypto/msm_pippenger.h
@@ -127,8 +127,7 @@ static inline bool msm_pippenger(const std::vector<ECPointA>& points,
             R = Secp256k1::add(R, acc);
         }
         if (!Secp256k1::is_infinity(buckets[0])){
-            acc = Secp256k1::add(acc, buckets[0]);
-            R = Secp256k1::add(R, acc);
+            R = Secp256k1::add(R, buckets[0]);
         }
     }
 

--- a/BitCrypto.Core/include/bitcrypto/rng.h
+++ b/BitCrypto.Core/include/bitcrypto/rng.h
@@ -3,7 +3,9 @@
 #include <cstddef>
 #include <cstring>
 #if defined(_WIN32)
+  #ifndef NOMINMAX
   #define NOMINMAX
+  #endif
   #include <windows.h>
   #include <bcrypt.h>
   #pragma comment(lib, "bcrypt.lib")
@@ -12,7 +14,8 @@
 namespace bitcrypto {
 inline bool rng_system(uint8_t* out, size_t n){
 #if defined(_WIN32)
-    return BCRYPT_SUCCESS == BCryptGenRandom(NULL, out, (ULONG)n, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
+    // STATUS_SUCCESS (0) indica sucesso na API CNG
+    return BCryptGenRandom(nullptr, out, (ULONG)n, BCRYPT_USE_SYSTEM_PREFERRED_RNG) == 0;
 #else
     // Fallback simples para ambientes não Windows (apenas para desenvolvimento)
     // Em produção Windows/VS2022, o caminho CNG acima é utilizado.

--- a/BitCrypto.Core/include/bitcrypto/rng.h
+++ b/BitCrypto.Core/include/bitcrypto/rng.h
@@ -5,7 +5,9 @@
   #include <windows.h>
   #include <bcrypt.h>
   #include <ntstatus.h>
-  #pragma comment(lib, "bcrypt.lib")
+  #if defined(_MSC_VER)
+    #pragma comment(lib, "bcrypt.lib")
+  #endif
   #undef min
   #undef max
 #endif

--- a/BitCrypto.Core/include/bitcrypto/rng.h
+++ b/BitCrypto.Core/include/bitcrypto/rng.h
@@ -1,21 +1,20 @@
 #pragma once
 #include <cstdint>
 #include <cstddef>
-#include <cstring>
 #if defined(_WIN32)
-  #ifndef NOMINMAX
-  #define NOMINMAX
-  #endif
   #include <windows.h>
   #include <bcrypt.h>
+  #include <ntstatus.h>
   #pragma comment(lib, "bcrypt.lib")
+  #undef min
+  #undef max
 #endif
 #include "base.h"
 namespace bitcrypto {
 inline bool rng_system(uint8_t* out, size_t n){
 #if defined(_WIN32)
-    // STATUS_SUCCESS (0) indica sucesso na API CNG
-    return BCryptGenRandom(nullptr, out, (ULONG)n, BCRYPT_USE_SYSTEM_PREFERRED_RNG) == 0;
+    NTSTATUS st = BCryptGenRandom(nullptr, out, (ULONG)n, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
+    return st == STATUS_SUCCESS;
 #else
     // Fallback simples para ambientes não Windows (apenas para desenvolvimento)
     // Em produção Windows/VS2022, o caminho CNG acima é utilizado.

--- a/BitCrypto.Core/tests/tests_endo_shamir.cpp
+++ b/BitCrypto.Core/tests/tests_endo_shamir.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <bitcrypto/endo_shamir.h>
+#include <bitcrypto/rng.h>
 
 using namespace bitcrypto;
 
@@ -16,17 +17,56 @@ int main(){
         U256 k{{0,0,0,0}}; U256 r1,r2; split_scalar_lambda(k,r1,r2);
         if (!r1.is_zero() || !r2.is_zero()){ std::cerr<<"split zero\n"; return 1; }
     }
-    // shamir_trick: a*P + b*G
+    // shamir_trick: compara a*P + b*G com a implementação direta
     {
         ECPointA G = Secp256k1::G();
-        U256 two{{2,0,0,0}}; ECPointA Q = Secp256k1::to_affine(Secp256k1::scalar_mul(two, G));
+        U256 two{{2,0,0,0}}; ECPointA P = Secp256k1::to_affine(Secp256k1::scalar_mul(two, G));
         U256 a{{1,0,0,0}}, b{{3,0,0,0}}; ECPointA R;
-        if(!shamir_trick(Q,a,b,R) || R.infinity){ std::cerr<<"shamir falhou\n"; return 1; }
+        if(!shamir_trick(P,a,b,R) || R.infinity){ std::cerr<<"shamir falhou\n"; return 1; }
+        ECPointJ ap = Secp256k1::scalar_mul(a, P);
+        ECPointJ bg = Secp256k1::scalar_mul(b, G);
+        ECPointA naive = Secp256k1::to_affine(Secp256k1::add(ap, bg));
+        if (R.x.v[0]!=naive.x.v[0]||R.x.v[1]!=naive.x.v[1]||R.x.v[2]!=naive.x.v[2]||R.x.v[3]!=naive.x.v[3]
+         || R.y.v[0]!=naive.y.v[0]||R.y.v[1]!=naive.y.v[1]||R.y.v[2]!=naive.y.v[2]||R.y.v[3]!=naive.y.v[3]){
+            std::cerr<<"shamir incorreto\n"; return 1;
+        }
+    }
+    // shamir_trick com escalares grandes (n-1)
+    {
+        ECPointA G = Secp256k1::G();
+        U256 k{{5,0,0,0}}; ECPointA P = Secp256k1::to_affine(Secp256k1::scalar_mul(k, G));
+        U256 nm1{{Fn::N[0]-1ULL,Fn::N[1],Fn::N[2],Fn::N[3]}}; ECPointA R;
+        if(!shamir_trick(P,nm1,nm1,R) || R.infinity || !Secp256k1::is_on_curve(R)){
+            std::cerr<<"shamir n-1 falhou\n"; return 1;
+        }
+    }
+    // shamir_trick com escalares aleatórios
+    {
+        ECPointA G = Secp256k1::G();
+        U256 a,b,kp; rng_system((uint8_t*)&a,sizeof(a)); rng_system((uint8_t*)&b,sizeof(b)); rng_system((uint8_t*)&kp,sizeof(kp));
+        a.v[3]|=0xFFFFFFFF00000000ULL; b.v[3]|=0xFFFFFFFF00000000ULL; kp.v[3]|=0xFFFFFFFF00000000ULL;
+        Secp256k1::scalar_mod_n(a); Secp256k1::scalar_mod_n(b); Secp256k1::scalar_mod_n(kp);
+        ECPointA P = Secp256k1::to_affine(Secp256k1::scalar_mul(kp, G));
+        ECPointA R;
+        if(!shamir_trick(P,a,b,R) || R.infinity){ std::cerr<<"shamir rand falhou\n"; return 1; }
+        ECPointJ ap = Secp256k1::scalar_mul(a, P);
+        ECPointJ bg = Secp256k1::scalar_mul(b, G);
+        ECPointA naive = Secp256k1::to_affine(Secp256k1::add(ap, bg));
+        if (R.x.v[0]!=naive.x.v[0]||R.x.v[1]!=naive.x.v[1]||R.x.v[2]!=naive.x.v[2]||R.x.v[3]!=naive.x.v[3]
+         || R.y.v[0]!=naive.y.v[0]||R.y.v[1]!=naive.y.v[1]||R.y.v[2]!=naive.y.v[2]||R.y.v[3]!=naive.y.v[3]){
+            std::cerr<<"shamir rand incorreto\n"; return 1;
+        }
     }
     // shamir_trick negativo: ponto infinito
     {
         ECPointA P{Fp::zero(),Fp::zero(),true}; U256 a{{1,0,0,0}}, b{{1,0,0,0}}; ECPointA R;
         if(shamir_trick(P,a,b,R)){ std::cerr<<"shamir deveria falhar\n"; return 1; }
+    }
+    // shamir_trick negativo: ponto inválido
+    {
+        ECPointA P{Fp::zero(),Fp::zero(),false}; U256 a{{1,0,0,0}}, b{{1,0,0,0}}; ECPointA R;
+        bool ok = shamir_trick(P,a,b,R);
+        if(ok && Secp256k1::is_on_curve(R)){ std::cerr<<"shamir aceitou ponto invalido\n"; return 1; }
     }
     std::cout<<"OK\n"; return 0;
 }

--- a/BitCrypto.Core/tests/tests_endo_shamir.cpp
+++ b/BitCrypto.Core/tests/tests_endo_shamir.cpp
@@ -65,8 +65,9 @@ int main(){
     // shamir_trick negativo: ponto inválido
     {
         ECPointA P{Fp::zero(),Fp::zero(),false}; U256 a{{1,0,0,0}}, b{{1,0,0,0}}; ECPointA R;
-        bool ok = shamir_trick(P,a,b,R);
-        if(ok && Secp256k1::is_on_curve(R)){ std::cerr<<"shamir aceitou ponto invalido\n"; return 1; }
+        if(shamir_trick(P,a,b,R)){
+            std::cerr<<"shamir aceitou ponto invalido\n"; return 1;
+        }
     }
     std::cout<<"OK\n"; return 0;
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,10 @@ target_include_directories(bitcrypto_common INTERFACE
   ${CMAKE_CURRENT_SOURCE_DIR}/BitCrypto.Math/include
   ${CMAKE_CURRENT_SOURCE_DIR}/BitCrypto.EC/include
 )
+# Link com a lib de entropia nativa no Windows
+if(WIN32)
+  target_link_libraries(bitcrypto_common INTERFACE bcrypt)
+endif()
 
 if(BITCRYPTO_ENABLE_CUDA)
   enable_language(CUDA)


### PR DESCRIPTION
## Summary
- exercise Shamir trick by comparing manual a·P + b·G with helper
- cover large scalars and randomized inputs, including invalid points
- fix Pippenger bucket accumulation to avoid double counting

## Testing
- `python tools/guardrails/check_constant_time_heuristic.py`
- `python tools/guardrails/check_no_external_deps.py`
- `python tools/guardrails/check_features.py`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68c335c59e448333bd4638567efb68a4