### PR TITLE
Limpa memória sensível no rfc6979_nonce

### DIFF
--- a/BitCrypto.Sign/include/bitcrypto/sign/sign.h
+++ b/BitCrypto.Sign/include/bitcrypto/sign/sign.h
@@ -59,6 +59,7 @@ inline bool ecdsa_sign(const uint8_t priv32[32], const uint8_t hash32[32], ECDSA
     U256 e = U256::from_be32(hash32); reduce_mod_n(e);
     uint8_t k32[32]; rfc6979_nonce(priv32, hash32, k32);
     U256 k = U256::from_be32(k32); Secp256k1::scalar_mod_n(k); if (k.is_zero()) return false;
+    secure_memzero(k32, sizeof(k32));
     ECPointJ Rj = Secp256k1::scalar_mul(k, Secp256k1::G());
     ECPointA Ra = Secp256k1::to_affine(Rj);
     U256 rx = Ra.x.to_u256_nm(); reduce_mod_n(rx); if (rx.is_zero()) return false; rx.to_be32(sig.r);

--- a/BitCrypto.Sign/include/bitcrypto/sign/sign.h
+++ b/BitCrypto.Sign/include/bitcrypto/sign/sign.h
@@ -45,7 +45,7 @@ inline void rfc6979_nonce(const uint8_t priv32[32], const uint8_t hash32[32], ui
         hmac_sha256(K, 32, sep, sizeof(sep), K);
         hmac_sha256(K, 32, V, 32, V);
     }
-    // limpa buffers temporários antes de retornar
+    // limpa buffers temporários (V, K, bx, tmp e sep) antes de retornar
     secure_memzero(&k, sizeof(k));
     secure_memzero(&t, sizeof(t));
     secure_memzero(V, sizeof(V));

--- a/BitCrypto.Sign/include/bitcrypto/sign/sign.h
+++ b/BitCrypto.Sign/include/bitcrypto/sign/sign.h
@@ -30,12 +30,13 @@ inline void rfc6979_nonce(const uint8_t priv32[32], const uint8_t hash32[32], ui
     hmac_sha256(K, 32, tmp, 33+33+32, K);
     hmac_sha256(K, 32, V, 32, V);
     uint8_t sep[1+33+32];
+    U256 k, t;
     while (true){
         hmac_sha256(K, 32, V, 32, V);
         std::memcpy(out_k, V, 32);
-        U256 k = U256::from_be32(out_k);
+        k = U256::from_be32(out_k);
         if (!k.is_zero()){
-            U256 t=k;
+            t = k;
             Secp256k1::scalar_mod_n(t);
             if (!t.is_zero()) break;
         }
@@ -45,6 +46,8 @@ inline void rfc6979_nonce(const uint8_t priv32[32], const uint8_t hash32[32], ui
         hmac_sha256(K, 32, V, 32, V);
     }
     // limpa buffers temporários antes de retornar
+    secure_memzero(&k, sizeof(k));
+    secure_memzero(&t, sizeof(t));
     secure_memzero(V, sizeof(V));
     secure_memzero(K, sizeof(K));
     secure_memzero(bx, sizeof(bx));

--- a/BitCrypto.Sign/include/bitcrypto/sign/sign.h
+++ b/BitCrypto.Sign/include/bitcrypto/sign/sign.h
@@ -55,26 +55,52 @@ struct ECDSA_Signature { uint8_t r[32]; uint8_t s[32]; };
 
 inline bool ecdsa_sign(const uint8_t priv32[32], const uint8_t hash32[32], ECDSA_Signature& sig, bool low_s=true){
     using namespace bitcrypto;
-    U256 d = U256::from_be32(priv32); Secp256k1::scalar_mod_n(d); if (d.is_zero()) return false;
-    U256 e = U256::from_be32(hash32); reduce_mod_n(e);
-    uint8_t k32[32]; rfc6979_nonce(priv32, hash32, k32);
-    U256 k = U256::from_be32(k32);
-    Secp256k1::scalar_mod_n(k);
+    bool ok=false;
+    U256 d = U256::from_be32(priv32);
+    U256 e = U256::from_be32(hash32);
+    uint8_t k32[32];
+    U256 k, rx, s;
+    ECPointJ Rj;
+    ECPointA Ra;
+    Fn kinv, s_m;
+    do {
+        Secp256k1::scalar_mod_n(d);
+        if (d.is_zero()) break;
+        reduce_mod_n(e);
+        rfc6979_nonce(priv32, hash32, k32);
+        k = U256::from_be32(k32);
+        Secp256k1::scalar_mod_n(k);
+        secure_memzero(k32, sizeof(k32));
+        if (k.is_zero()) break;
+        Rj = Secp256k1::scalar_mul(k, Secp256k1::G());
+        Ra = Secp256k1::to_affine(Rj);
+        rx = Ra.x.to_u256_nm();
+        reduce_mod_n(rx);
+        if (rx.is_zero()) break;
+        rx.to_be32(sig.r);
+        kinv = Fn::inv(Fn::from_u256_nm(k));
+        s_m = Fn::mul(kinv, Fn::add(Fn::from_u256_nm(e), Fn::mul(Fn::from_u256_nm(rx), Fn::from_u256_nm(d))));
+        s = s_m.to_u256_nm();
+        if (low_s){
+            const uint64_t N[4]={0xBFD25E8CD0364141ULL,0xBAAEDCE6AF48A03BULL,0xFFFFFFFFFFFFFFFEULL,0xFFFFFFFFFFFFFFFFULL};
+            uint64_t halfN[4] = {N[0]>>1 | (N[1]&1?0x8000000000000000ULL:0), (N[1]>>1) | (N[2]&1?0x8000000000000000ULL:0), (N[2]>>1) | (N[3]&1?0x8000000000000000ULL:0), (N[3]>>1)};
+            bool gt=false; for (int i=3;i>=0;i--){ if (s.v[i]>halfN[i]) { gt=true; break; } else if (s.v[i]<halfN[i]) break; } if (gt){ uint64_t br=0; s.v[0]=subb64(N[0],s.v[0],br); s.v[1]=subb64(N[1],s.v[1],br); s.v[2]=subb64(N[2],s.v[2],br); s.v[3]=subb64(N[3],s.v[3],br); }
+        }
+        s.to_be32(sig.s);
+        ok = !is_zero32(sig.s);
+    } while(false);
+    // limpa segredos antes de sair
+    secure_memzero(&d, sizeof(d));
+    secure_memzero(&e, sizeof(e));
     secure_memzero(k32, sizeof(k32));
-    if (k.is_zero()) return false;
-    ECPointJ Rj = Secp256k1::scalar_mul(k, Secp256k1::G());
-    ECPointA Ra = Secp256k1::to_affine(Rj);
-    U256 rx = Ra.x.to_u256_nm(); reduce_mod_n(rx); if (rx.is_zero()) return false; rx.to_be32(sig.r);
-    Fn kinv = Fn::inv(Fn::from_u256_nm(k));
-    Fn s_m = Fn::mul(kinv, Fn::add(Fn::from_u256_nm(e), Fn::mul(Fn::from_u256_nm(rx), Fn::from_u256_nm(d))));
-    U256 s = s_m.to_u256_nm();
-    if (low_s){
-        const uint64_t N[4]={0xBFD25E8CD0364141ULL,0xBAAEDCE6AF48A03BULL,0xFFFFFFFFFFFFFFFEULL,0xFFFFFFFFFFFFFFFFULL};
-        uint64_t halfN[4] = {N[0]>>1 | (N[1]&1?0x8000000000000000ULL:0), (N[1]>>1) | (N[2]&1?0x8000000000000000ULL:0), (N[2]>>1) | (N[3]&1?0x8000000000000000ULL:0), (N[3]>>1)};
-        bool gt=false; for (int i=3;i>=0;i--){ if (s.v[i]>halfN[i]) { gt=true; break; } else if (s.v[i]<halfN[i]) break; } if (gt){ uint64_t br=0; s.v[0]=subb64(N[0],s.v[0],br); s.v[1]=subb64(N[1],s.v[1],br); s.v[2]=subb64(N[2],s.v[2],br); s.v[3]=subb64(N[3],s.v[3],br); }
-    }
-    s.to_be32(sig.s);
-    return !is_zero32(sig.s);
+    secure_memzero(&k, sizeof(k));
+    secure_memzero(&rx, sizeof(rx));
+    secure_memzero(&kinv, sizeof(kinv));
+    secure_memzero(&s_m, sizeof(s_m));
+    secure_memzero(&s, sizeof(s));
+    secure_memzero(&Rj, sizeof(Rj));
+    secure_memzero(&Ra, sizeof(Ra));
+    return ok;
 }
 
 // Alias de compatibilidade com a nomenclatura anterior

--- a/BitCrypto.Sign/include/bitcrypto/sign/sign.h
+++ b/BitCrypto.Sign/include/bitcrypto/sign/sign.h
@@ -44,6 +44,7 @@ inline void rfc6979_nonce(const uint8_t priv32[32], const uint8_t hash32[32], ui
         hmac_sha256(K, 32, sep, sizeof(sep), K);
         hmac_sha256(K, 32, V, 32, V);
     }
+    // limpa buffers temporários antes de retornar
     secure_memzero(V, sizeof(V));
     secure_memzero(K, sizeof(K));
     secure_memzero(bx, sizeof(bx));

--- a/BitCrypto.Sign/include/bitcrypto/sign/sign.h
+++ b/BitCrypto.Sign/include/bitcrypto/sign/sign.h
@@ -58,8 +58,10 @@ inline bool ecdsa_sign(const uint8_t priv32[32], const uint8_t hash32[32], ECDSA
     U256 d = U256::from_be32(priv32); Secp256k1::scalar_mod_n(d); if (d.is_zero()) return false;
     U256 e = U256::from_be32(hash32); reduce_mod_n(e);
     uint8_t k32[32]; rfc6979_nonce(priv32, hash32, k32);
-    U256 k = U256::from_be32(k32); Secp256k1::scalar_mod_n(k); if (k.is_zero()) return false;
+    U256 k = U256::from_be32(k32);
+    Secp256k1::scalar_mod_n(k);
     secure_memzero(k32, sizeof(k32));
+    if (k.is_zero()) return false;
     ECPointJ Rj = Secp256k1::scalar_mul(k, Secp256k1::G());
     ECPointA Ra = Secp256k1::to_affine(Rj);
     U256 rx = Ra.x.to_u256_nm(); reduce_mod_n(rx); if (rx.is_zero()) return false; rx.to_be32(sig.r);

--- a/MANIFEST_v2.5.0.txt
+++ b/MANIFEST_v2.5.0.txt
@@ -170,7 +170,7 @@ f55bb0e34a0d4f2d678a3f794661cc5ce7f133731adc76fd54df1b75555af481          16  Bi
 5f33c0d497ef6788f389c884f925fd712ce11a8d5ca516bd83a8ad3d94eb973e        4957  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/scalar_n.h
 f9c8121680a6a2f2964ef8c45e242e8191cd1da618fe549ee3f5f55b8545630a        2194  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/der.h
 fc8ec875e343fc13a13f671618f541ae2b354293232b488e95c4501aba276791        5751  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/schnorr.h
-fb6c2da638011eacb66902348cedc6e4a31dfbf6a54a9200dee2dca63b391e75        9676  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/sign.h
+3eb650055c583b2daee25dffce8ad428777df3ab0fb7e73ba49cd736f11d704e        9961  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/sign.h
 64e1cb225d352ab2b89471972574617c4bdc0cda350eafb9d464bd359a69ebf0        1504  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/rfc6979.h
 68ecf6830ece5aa7121c3fdbaf540597d2d55d6517f213342868bf373dd38347        5168  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/ecdsa.h
 3f6e83c42ca5eebb6cc0e94e2579da5857a25e93dd344ec2f86e9407a7a09ee3         198  BitCrypto/BitCrypto.Hash/CMakeLists.txt

--- a/MANIFEST_v2.5.0.txt
+++ b/MANIFEST_v2.5.0.txt
@@ -170,7 +170,7 @@ f55bb0e34a0d4f2d678a3f794661cc5ce7f133731adc76fd54df1b75555af481          16  Bi
 5f33c0d497ef6788f389c884f925fd712ce11a8d5ca516bd83a8ad3d94eb973e        4957  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/scalar_n.h
 f9c8121680a6a2f2964ef8c45e242e8191cd1da618fe549ee3f5f55b8545630a        2194  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/der.h
 fc8ec875e343fc13a13f671618f541ae2b354293232b488e95c4501aba276791        5751  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/schnorr.h
-aa6bdd802711cc236e80a75735f663b7c47f0a47c7194dfb9288a381bfc35976       10608  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/sign.h
+7cb188f83caa039a058e50db7514e9a92dc4a4dc947729e40c0ec87b873f22e8       10660  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/sign.h
 64e1cb225d352ab2b89471972574617c4bdc0cda350eafb9d464bd359a69ebf0        1504  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/rfc6979.h
 68ecf6830ece5aa7121c3fdbaf540597d2d55d6517f213342868bf373dd38347        5168  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/ecdsa.h
 3f6e83c42ca5eebb6cc0e94e2579da5857a25e93dd344ec2f86e9407a7a09ee3         198  BitCrypto/BitCrypto.Hash/CMakeLists.txt

--- a/MANIFEST_v2.5.0.txt
+++ b/MANIFEST_v2.5.0.txt
@@ -170,7 +170,7 @@ f55bb0e34a0d4f2d678a3f794661cc5ce7f133731adc76fd54df1b75555af481          16  Bi
 5f33c0d497ef6788f389c884f925fd712ce11a8d5ca516bd83a8ad3d94eb973e        4957  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/scalar_n.h
 f9c8121680a6a2f2964ef8c45e242e8191cd1da618fe549ee3f5f55b8545630a        2194  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/der.h
 fc8ec875e343fc13a13f671618f541ae2b354293232b488e95c4501aba276791        5751  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/schnorr.h
-198bee3331b4ca41bc74534662c1f6d518033124f7a473e818a892d0e0a34593        10737  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/sign.h
+a6e8689e83c146474781699a7db6c387f3f4a54c73d4f42d638f767cb5c223f9        10759  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/sign.h
 64e1cb225d352ab2b89471972574617c4bdc0cda350eafb9d464bd359a69ebf0        1504  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/rfc6979.h
 68ecf6830ece5aa7121c3fdbaf540597d2d55d6517f213342868bf373dd38347        5168  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/ecdsa.h
 3f6e83c42ca5eebb6cc0e94e2579da5857a25e93dd344ec2f86e9407a7a09ee3         198  BitCrypto/BitCrypto.Hash/CMakeLists.txt

--- a/MANIFEST_v2.5.0.txt
+++ b/MANIFEST_v2.5.0.txt
@@ -170,7 +170,7 @@ f55bb0e34a0d4f2d678a3f794661cc5ce7f133731adc76fd54df1b75555af481          16  Bi
 5f33c0d497ef6788f389c884f925fd712ce11a8d5ca516bd83a8ad3d94eb973e        4957  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/scalar_n.h
 f9c8121680a6a2f2964ef8c45e242e8191cd1da618fe549ee3f5f55b8545630a        2194  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/der.h
 fc8ec875e343fc13a13f671618f541ae2b354293232b488e95c4501aba276791        5751  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/schnorr.h
-7cb188f83caa039a058e50db7514e9a92dc4a4dc947729e40c0ec87b873f22e8       10660  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/sign.h
+198bee3331b4ca41bc74534662c1f6d518033124f7a473e818a892d0e0a34593        10737  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/sign.h
 64e1cb225d352ab2b89471972574617c4bdc0cda350eafb9d464bd359a69ebf0        1504  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/rfc6979.h
 68ecf6830ece5aa7121c3fdbaf540597d2d55d6517f213342868bf373dd38347        5168  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/ecdsa.h
 3f6e83c42ca5eebb6cc0e94e2579da5857a25e93dd344ec2f86e9407a7a09ee3         198  BitCrypto/BitCrypto.Hash/CMakeLists.txt

--- a/MANIFEST_v2.5.0.txt
+++ b/MANIFEST_v2.5.0.txt
@@ -170,7 +170,7 @@ f55bb0e34a0d4f2d678a3f794661cc5ce7f133731adc76fd54df1b75555af481          16  Bi
 5f33c0d497ef6788f389c884f925fd712ce11a8d5ca516bd83a8ad3d94eb973e        4957  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/scalar_n.h
 f9c8121680a6a2f2964ef8c45e242e8191cd1da618fe549ee3f5f55b8545630a        2194  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/der.h
 fc8ec875e343fc13a13f671618f541ae2b354293232b488e95c4501aba276791        5751  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/schnorr.h
-2d1f8386dd6b229cbf866a5e83404c79af414d4a2bbdb4b5ddc0e5fafb838528        9999  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/sign.h
+8c370dbea939f0ac0a51becbcd82a61b29815435879b382ed43408562266c830       10007  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/sign.h
 64e1cb225d352ab2b89471972574617c4bdc0cda350eafb9d464bd359a69ebf0        1504  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/rfc6979.h
 68ecf6830ece5aa7121c3fdbaf540597d2d55d6517f213342868bf373dd38347        5168  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/ecdsa.h
 3f6e83c42ca5eebb6cc0e94e2579da5857a25e93dd344ec2f86e9407a7a09ee3         198  BitCrypto/BitCrypto.Hash/CMakeLists.txt

--- a/MANIFEST_v2.5.0.txt
+++ b/MANIFEST_v2.5.0.txt
@@ -170,7 +170,7 @@ f55bb0e34a0d4f2d678a3f794661cc5ce7f133731adc76fd54df1b75555af481          16  Bi
 5f33c0d497ef6788f389c884f925fd712ce11a8d5ca516bd83a8ad3d94eb973e        4957  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/scalar_n.h
 f9c8121680a6a2f2964ef8c45e242e8191cd1da618fe549ee3f5f55b8545630a        2194  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/der.h
 fc8ec875e343fc13a13f671618f541ae2b354293232b488e95c4501aba276791        5751  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/schnorr.h
-3eb650055c583b2daee25dffce8ad428777df3ab0fb7e73ba49cd736f11d704e        9961  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/sign.h
+2d1f8386dd6b229cbf866a5e83404c79af414d4a2bbdb4b5ddc0e5fafb838528        9999  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/sign.h
 64e1cb225d352ab2b89471972574617c4bdc0cda350eafb9d464bd359a69ebf0        1504  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/rfc6979.h
 68ecf6830ece5aa7121c3fdbaf540597d2d55d6517f213342868bf373dd38347        5168  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/ecdsa.h
 3f6e83c42ca5eebb6cc0e94e2579da5857a25e93dd344ec2f86e9407a7a09ee3         198  BitCrypto/BitCrypto.Hash/CMakeLists.txt

--- a/MANIFEST_v2.5.0.txt
+++ b/MANIFEST_v2.5.0.txt
@@ -170,7 +170,7 @@ f55bb0e34a0d4f2d678a3f794661cc5ce7f133731adc76fd54df1b75555af481          16  Bi
 5f33c0d497ef6788f389c884f925fd712ce11a8d5ca516bd83a8ad3d94eb973e        4957  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/scalar_n.h
 f9c8121680a6a2f2964ef8c45e242e8191cd1da618fe549ee3f5f55b8545630a        2194  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/der.h
 fc8ec875e343fc13a13f671618f541ae2b354293232b488e95c4501aba276791        5751  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/schnorr.h
-8c370dbea939f0ac0a51becbcd82a61b29815435879b382ed43408562266c830       10007  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/sign.h
+aa6bdd802711cc236e80a75735f663b7c47f0a47c7194dfb9288a381bfc35976       10608  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/sign.h
 64e1cb225d352ab2b89471972574617c4bdc0cda350eafb9d464bd359a69ebf0        1504  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/rfc6979.h
 68ecf6830ece5aa7121c3fdbaf540597d2d55d6517f213342868bf373dd38347        5168  BitCrypto/BitCrypto.Sign/include/bitcrypto/sign/ecdsa.h
 3f6e83c42ca5eebb6cc0e94e2579da5857a25e93dd344ec2f86e9407a7a09ee3         198  BitCrypto/BitCrypto.Hash/CMakeLists.txt


### PR DESCRIPTION
## Resumo
- inclui safe.h e limpa buffers sensíveis após gerar nonce RFC6979
- atualiza MANIFEST v2.5.0

## Testes
- `python tools/guardrails/check_constant_time_heuristic.py`
- `python tools/guardrails/check_no_external_deps.py`
- `python tools/guardrails/check_manifest.py`
- `python tools/guardrails/check_stubs.py`
- `python tools/guardrails/check_features.py`
- `ctest` *(falhou: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68c35756cd9c8333b76986ae47331e91