### PR TITLE
RNG: suporte a getrandom ou /dev/urandom em Unix

### DIFF
--- a/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+++ b/BitCrypto.RNG/include/bitcrypto/rng/rng.h
@@ -2,6 +2,7 @@
 #include <cstdint>
 #include <cstddef>
 #include <limits>
+#include <type_traits>
 #ifdef _WIN32
   #include <windows.h>
   #include <bcrypt.h>
@@ -253,5 +254,19 @@ enum class getrandom_result {
 #endif
     return detail::fill_from_urandom(out, n, off);
 #endif
+}
+
+// Sobrecarga de conveniência para buffers genéricos.
+[[nodiscard]] inline bool random_bytes(void* out, size_t n) {
+    return random_bytes(static_cast<uint8_t*>(out), n);
+}
+
+// Gera um valor aleatório para tipos triviais (ex.: inteiros, structs `struct POD`).
+template <typename T>
+[[nodiscard]] inline bool random_value(T& value) {
+    static_assert(std::is_trivially_copyable<T>::value,
+                  "random_value requer tipos trivialmente copiáveis");
+    static_assert(!std::is_pointer<T>::value, "random_value não aceita ponteiros");
+    return random_bytes(reinterpret_cast<uint8_t*>(&value), sizeof(T));
 }
 }} // ns

--- a/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+++ b/BitCrypto.RNG/include/bitcrypto/rng/rng.h
@@ -20,7 +20,7 @@ namespace bitcrypto { namespace rng {
 // Retorna true em caso de sucesso.
 // No Windows usa o RNG preferido do sistema (CNG);
 // em Unix tenta `getrandom()` e cai para `/dev/urandom` quando necessário.
-inline bool random_bytes(uint8_t* out, size_t n){
+inline bool random_bytes(uint8_t* out, size_t n) {
 #ifdef _WIN32
     NTSTATUS st = BCryptGenRandom(nullptr, reinterpret_cast<PUCHAR>(out), (ULONG)n, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
     return BCRYPT_SUCCESS(st);

--- a/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+++ b/BitCrypto.RNG/include/bitcrypto/rng/rng.h
@@ -148,6 +148,18 @@ inline bool fill_from_urandom(uint8_t* out, size_t n, size_t off) {
 // No Windows usa o RNG preferido do sistema (CNG);
 // em Unix tenta `getrandom()` e cai para `/dev/urandom` quando necessário.
 inline bool random_bytes(uint8_t* out, size_t n) {
+    // Rejeita ponteiros nulos quando há bytes a preencher, preservando a propagação de erro.
+    if (out == nullptr) {
+        if (n == 0) {
+            return true;
+        }
+#ifdef _WIN32
+        ::SetLastError(ERROR_INVALID_PARAMETER);
+#else
+        errno = EINVAL;
+#endif
+        return false;
+    }
     if (n == 0) {
         return true;
     }

--- a/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+++ b/BitCrypto.RNG/include/bitcrypto/rng/rng.h
@@ -2,8 +2,14 @@
 #include <cstdint>
 #include <cstddef>
 #ifdef _WIN32
+  #include <windows.h>
   #include <bcrypt.h>
-  #pragma comment(lib, "bcrypt.lib")
+  #include <ntstatus.h>
+  #if defined(_MSC_VER)
+    #pragma comment(lib, "bcrypt.lib")
+  #endif
+  #undef min
+  #undef max
 #else
   // Dependência: fontes de entropia do sistema (`getrandom()` ou `/dev/urandom`).
   // O descritor é aberto com `O_CLOEXEC`, chamadas repetem em caso de EINTR/EAGAIN

--- a/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+++ b/BitCrypto.RNG/include/bitcrypto/rng/rng.h
@@ -23,6 +23,42 @@
     #include <sys/random.h>
   #endif
 #endif
+#ifndef _WIN32
+namespace {
+// Fecha descritores preservando errno original em caminhos de erro.
+inline bool close_fd_preserve(int fd, int restore_errno) {
+    if (fd < 0) {
+        return true;
+    }
+    int rc;
+    do {
+        rc = ::close(fd);
+    } while (rc != 0 && errno == EINTR);
+    if (rc != 0) {
+        return false;
+    }
+    errno = restore_errno;
+    return true;
+}
+
+// Fecha descritores restaurando errno anterior em caminhos de sucesso.
+inline bool close_fd_noerrno(int fd) {
+    if (fd < 0) {
+        return true;
+    }
+    int saved_errno = errno;
+    int rc;
+    do {
+        rc = ::close(fd);
+    } while (rc != 0 && errno == EINTR);
+    if (rc != 0) {
+        return false;
+    }
+    errno = saved_errno;
+    return true;
+}
+} // namespace
+#endif
 namespace bitcrypto { namespace rng {
 // Retorna true em caso de sucesso.
 // No Windows usa o RNG preferido do sistema (CNG);
@@ -82,20 +118,18 @@ inline bool random_bytes(uint8_t* out, size_t n) {
         if (r < 0) {
             if (errno == EINTR || errno == EAGAIN) continue;
             int err = errno;
-            if (::close(fd) != 0) {
-                return false; // errno já reflete a falha em close()
+            if (!close_fd_preserve(fd, err)) {
+                return false;
             }
-            errno = err;
             return false;
         }
         // `read()` retornou 0: `/dev/urandom` não entregou dados; sinaliza erro.
-        if (::close(fd) != 0) {
+        if (!close_fd_preserve(fd, EIO)) {
             return false;
         }
-        errno = EIO;
         return false;
     }
-    if (::close(fd) != 0) {
+    if (!close_fd_noerrno(fd)) {
         return false;
     }
     return true;

--- a/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+++ b/BitCrypto.RNG/include/bitcrypto/rng/rng.h
@@ -11,6 +11,7 @@
   #include <unistd.h>
   #include <fcntl.h>
   #include <errno.h>
+  #include <sys/types.h> // ssize_t
   #ifdef __linux__
     #include <sys/random.h>
   #endif

--- a/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+++ b/BitCrypto.RNG/include/bitcrypto/rng/rng.h
@@ -40,7 +40,7 @@ inline bool random_bytes(uint8_t* out, size_t n) {
     if (off == n) return true;
 #endif
     // Fallback genérico: leitura de /dev/urandom.
-    int fd;
+    int fd = -1;
     for (;;) {
         fd = ::open("/dev/urandom", O_RDONLY | O_CLOEXEC);
         if (fd >= 0) break;

--- a/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+++ b/BitCrypto.RNG/include/bitcrypto/rng/rng.h
@@ -51,7 +51,9 @@ inline bool random_bytes(uint8_t* out, size_t n) {
         ssize_t r = ::read(fd, out + off, n - off);
         if (r <= 0) {
             if (r < 0 && (errno == EINTR || errno == EAGAIN)) continue;
+            int err = errno;
             ::close(fd);
+            errno = err;
             return false;
         }
         off += static_cast<size_t>(r);

--- a/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+++ b/BitCrypto.RNG/include/bitcrypto/rng/rng.h
@@ -50,6 +50,10 @@ inline bool random_bytes(uint8_t* out, size_t n) {
             if (errno == ENOSYS || errno == EINVAL || errno == EPERM) break; // fallback
             return false;
         }
+        if (r == 0) {
+            errno = EIO;
+            break; // força fallback para /dev/urandom
+        }
         off += static_cast<size_t>(r);
     }
     if (off == n) return true;

--- a/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+++ b/BitCrypto.RNG/include/bitcrypto/rng/rng.h
@@ -22,7 +22,7 @@ namespace bitcrypto { namespace rng {
 inline bool random_bytes(uint8_t* out, size_t n){
 #ifdef _WIN32
     NTSTATUS st = BCryptGenRandom(nullptr, reinterpret_cast<PUCHAR>(out), (ULONG)n, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
-    return st==0;
+    return BCRYPT_SUCCESS(st);
 #else
     size_t off = 0;
 #ifdef __linux__
@@ -54,4 +54,4 @@ inline bool random_bytes(uint8_t* out, size_t n){
     return true;
 #endif
 }
-}}
+}} // ns

--- a/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+++ b/BitCrypto.RNG/include/bitcrypto/rng/rng.h
@@ -4,7 +4,6 @@
 #ifdef _WIN32
   #include <windows.h>
   #include <bcrypt.h>
-  #include <ntstatus.h>
   #if defined(_MSC_VER)
     #pragma comment(lib, "bcrypt.lib")
   #endif

--- a/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+++ b/BitCrypto.RNG/include/bitcrypto/rng/rng.h
@@ -5,7 +5,8 @@
   #include <bcrypt.h>
   #pragma comment(lib, "bcrypt.lib")
 #else
-  // Dependência: getrandom() (Linux) ou dispositivo especial /dev/urandom.
+  // Dependência: fontes de entropia do sistema (`getrandom()` ou `/dev/urandom`).
+  // O descritor é aberto com `O_CLOEXEC` e erros são propagados ao chamador.
   #include <sys/types.h>
   #include <unistd.h>
   #include <fcntl.h>
@@ -15,10 +16,12 @@
   #endif
 #endif
 namespace bitcrypto { namespace rng {
-// Retorna true em caso de sucesso. Usa o RNG preferido do sistema (Windows CNG).
+// Retorna true em caso de sucesso.
+// No Windows usa o RNG preferido do sistema (CNG);
+// em Unix tenta `getrandom()` e cai para `/dev/urandom` quando necessário.
 inline bool random_bytes(uint8_t* out, size_t n){
 #ifdef _WIN32
-    NTSTATUS st = BCryptGenRandom(nullptr, (PUCHAR)out, (ULONG)n, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
+    NTSTATUS st = BCryptGenRandom(nullptr, reinterpret_cast<PUCHAR>(out), (ULONG)n, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
     return st==0;
 #else
     size_t off = 0;

--- a/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+++ b/BitCrypto.RNG/include/bitcrypto/rng/rng.h
@@ -40,14 +40,15 @@ inline bool random_bytes(uint8_t* out, size_t n){
 #endif
     // Fallback genérico: leitura de /dev/urandom.
     int fd;
-    do {
+    for (;;) {
         fd = ::open("/dev/urandom", O_RDONLY | O_CLOEXEC);
-    } while (fd < 0 && errno == EINTR);
-    if (fd < 0) return false;
+        if (fd >= 0) break;
+        if (errno != EINTR && errno != EAGAIN) return false;
+    }
     while (off < n) {
         ssize_t r = ::read(fd, out + off, n - off);
         if (r <= 0) {
-            if (r < 0 && errno == EINTR) continue;
+            if (r < 0 && (errno == EINTR || errno == EAGAIN)) continue;
             ::close(fd);
             return false;
         }

--- a/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+++ b/BitCrypto.RNG/include/bitcrypto/rng/rng.h
@@ -39,7 +39,10 @@ inline bool random_bytes(uint8_t* out, size_t n){
     if (off == n) return true;
 #endif
     // Fallback genérico: leitura de /dev/urandom.
-    int fd = ::open("/dev/urandom", O_RDONLY | O_CLOEXEC);
+    int fd;
+    do {
+        fd = ::open("/dev/urandom", O_RDONLY | O_CLOEXEC);
+    } while (fd < 0 && errno == EINTR);
     if (fd < 0) return false;
     while (off < n) {
         ssize_t r = ::read(fd, out + off, n - off);

--- a/MANIFEST_v2.5.0.txt
+++ b/MANIFEST_v2.5.0.txt
@@ -26,7 +26,7 @@ d0f1b66d172a3d6fb7a4db68b1f794a88dffb512b8caf0286c91ba8b76c09efd        1017  Bi
 e134c5e7ecacd36bb4cb054210a70abaf8461eedae707e641fc4998405bbcf5d        3546  BitCrypto/BitCrypto.WSCLI/src/main.cpp
 22cb673c5252d0dc81f0bc82f6b5f1651399139431e5092dd9a1c265ecfb91ed         289  BitCrypto/BitCrypto.RNG/CMakeLists.txt
 f55bb0e34a0d4f2d678a3f794661cc5ce7f133731adc76fd54df1b75555af481          16  BitCrypto/BitCrypto.RNG/src/unity.cpp
-e7aa921b285112a48db07e46d5db41c0df01cc298a5f316236d83cbf4e066f18        1919  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+639743caf6b15e88ddadaac1c3ce734a99c71d312955fa4e96a1fff9ee7168c9        1955  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
 4543a3b0b1193fe5a151b3ae04f2c4b5875b1afcdaf88610ef4904c0a134abd5         455  BitCrypto/BitCrypto.PSBTCLI/CMakeLists.txt
 2972187d8c9162047959eb9f38656513d49b234ec0e7eabe29fa2cec40e97e19       12904  BitCrypto/BitCrypto.PSBTCLI/src/main.cpp
 d0c91641d3609926b9197e6cda79931238b4b423d8600ad30c83c5fbb9c8c491         762  BitCrypto/BitCrypto.CLI/CMakeLists.txt

--- a/MANIFEST_v2.5.0.txt
+++ b/MANIFEST_v2.5.0.txt
@@ -26,7 +26,7 @@ d0f1b66d172a3d6fb7a4db68b1f794a88dffb512b8caf0286c91ba8b76c09efd        1017  Bi
 e134c5e7ecacd36bb4cb054210a70abaf8461eedae707e641fc4998405bbcf5d        3546  BitCrypto/BitCrypto.WSCLI/src/main.cpp
 22cb673c5252d0dc81f0bc82f6b5f1651399139431e5092dd9a1c265ecfb91ed         289  BitCrypto/BitCrypto.RNG/CMakeLists.txt
 f55bb0e34a0d4f2d678a3f794661cc5ce7f133731adc76fd54df1b75555af481          16  BitCrypto/BitCrypto.RNG/src/unity.cpp
-3ee4c86e75ee0d40d93e77fb98feb6408e422e6b57600491c6dfa6d1def62fd1        1961  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+547abc0a95419f1bcb864b352e35431730373dfcca737877a5c3e3a05a67b37a        2072  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
 4543a3b0b1193fe5a151b3ae04f2c4b5875b1afcdaf88610ef4904c0a134abd5         455  BitCrypto/BitCrypto.PSBTCLI/CMakeLists.txt
 2972187d8c9162047959eb9f38656513d49b234ec0e7eabe29fa2cec40e97e19       12904  BitCrypto/BitCrypto.PSBTCLI/src/main.cpp
 d0c91641d3609926b9197e6cda79931238b4b423d8600ad30c83c5fbb9c8c491         762  BitCrypto/BitCrypto.CLI/CMakeLists.txt

--- a/MANIFEST_v2.5.0.txt
+++ b/MANIFEST_v2.5.0.txt
@@ -26,7 +26,7 @@ d0f1b66d172a3d6fb7a4db68b1f794a88dffb512b8caf0286c91ba8b76c09efd        1017  Bi
 e134c5e7ecacd36bb4cb054210a70abaf8461eedae707e641fc4998405bbcf5d        3546  BitCrypto/BitCrypto.WSCLI/src/main.cpp
 22cb673c5252d0dc81f0bc82f6b5f1651399139431e5092dd9a1c265ecfb91ed         289  BitCrypto/BitCrypto.RNG/CMakeLists.txt
 f55bb0e34a0d4f2d678a3f794661cc5ce7f133731adc76fd54df1b75555af481          16  BitCrypto/BitCrypto.RNG/src/unity.cpp
-27f8a3f90151de3f763ef96371c0253ac2b93ef73dee73ca7757bba00c75acb4        2126  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+8afb8ca62f914d35f666687e23fd047293c624e34a712aa855f8ef934b867416        2234  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
 4543a3b0b1193fe5a151b3ae04f2c4b5875b1afcdaf88610ef4904c0a134abd5         455  BitCrypto/BitCrypto.PSBTCLI/CMakeLists.txt
 2972187d8c9162047959eb9f38656513d49b234ec0e7eabe29fa2cec40e97e19       12904  BitCrypto/BitCrypto.PSBTCLI/src/main.cpp
 d0c91641d3609926b9197e6cda79931238b4b423d8600ad30c83c5fbb9c8c491         762  BitCrypto/BitCrypto.CLI/CMakeLists.txt

--- a/MANIFEST_v2.5.0.txt
+++ b/MANIFEST_v2.5.0.txt
@@ -26,7 +26,7 @@ d0f1b66d172a3d6fb7a4db68b1f794a88dffb512b8caf0286c91ba8b76c09efd        1017  Bi
 e134c5e7ecacd36bb4cb054210a70abaf8461eedae707e641fc4998405bbcf5d        3546  BitCrypto/BitCrypto.WSCLI/src/main.cpp
 22cb673c5252d0dc81f0bc82f6b5f1651399139431e5092dd9a1c265ecfb91ed         289  BitCrypto/BitCrypto.RNG/CMakeLists.txt
 f55bb0e34a0d4f2d678a3f794661cc5ce7f133731adc76fd54df1b75555af481          16  BitCrypto/BitCrypto.RNG/src/unity.cpp
-d5bddbc7228fd626120a21ddf600162d1480cad1dfee02f2f17f7a8fddb1b1ba        4625  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+dc40664a27b317f9625b92463e197586d431141b94fc70080e0ad9af60eaeff9        4933  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
 4543a3b0b1193fe5a151b3ae04f2c4b5875b1afcdaf88610ef4904c0a134abd5         455  BitCrypto/BitCrypto.PSBTCLI/CMakeLists.txt
 2972187d8c9162047959eb9f38656513d49b234ec0e7eabe29fa2cec40e97e19       12904  BitCrypto/BitCrypto.PSBTCLI/src/main.cpp
 d0c91641d3609926b9197e6cda79931238b4b423d8600ad30c83c5fbb9c8c491         762  BitCrypto/BitCrypto.CLI/CMakeLists.txt

--- a/MANIFEST_v2.5.0.txt
+++ b/MANIFEST_v2.5.0.txt
@@ -26,7 +26,7 @@ d0f1b66d172a3d6fb7a4db68b1f794a88dffb512b8caf0286c91ba8b76c09efd        1017  Bi
 e134c5e7ecacd36bb4cb054210a70abaf8461eedae707e641fc4998405bbcf5d        3546  BitCrypto/BitCrypto.WSCLI/src/main.cpp
 22cb673c5252d0dc81f0bc82f6b5f1651399139431e5092dd9a1c265ecfb91ed         289  BitCrypto/BitCrypto.RNG/CMakeLists.txt
 f55bb0e34a0d4f2d678a3f794661cc5ce7f133731adc76fd54df1b75555af481          16  BitCrypto/BitCrypto.RNG/src/unity.cpp
-4e80a75399f38b2819108007bc069d93cf0e7e47adbee822907da9d600825786        3191  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+9f76018bda4cd7530d382925a67402d6ba3261249d5be3f76a2005167a7e37b5        3900  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
 4543a3b0b1193fe5a151b3ae04f2c4b5875b1afcdaf88610ef4904c0a134abd5         455  BitCrypto/BitCrypto.PSBTCLI/CMakeLists.txt
 2972187d8c9162047959eb9f38656513d49b234ec0e7eabe29fa2cec40e97e19       12904  BitCrypto/BitCrypto.PSBTCLI/src/main.cpp
 d0c91641d3609926b9197e6cda79931238b4b423d8600ad30c83c5fbb9c8c491         762  BitCrypto/BitCrypto.CLI/CMakeLists.txt

--- a/MANIFEST_v2.5.0.txt
+++ b/MANIFEST_v2.5.0.txt
@@ -26,7 +26,7 @@ d0f1b66d172a3d6fb7a4db68b1f794a88dffb512b8caf0286c91ba8b76c09efd        1017  Bi
 e134c5e7ecacd36bb4cb054210a70abaf8461eedae707e641fc4998405bbcf5d        3546  BitCrypto/BitCrypto.WSCLI/src/main.cpp
 22cb673c5252d0dc81f0bc82f6b5f1651399139431e5092dd9a1c265ecfb91ed         289  BitCrypto/BitCrypto.RNG/CMakeLists.txt
 f55bb0e34a0d4f2d678a3f794661cc5ce7f133731adc76fd54df1b75555af481          16  BitCrypto/BitCrypto.RNG/src/unity.cpp
-8afb8ca62f914d35f666687e23fd047293c624e34a712aa855f8ef934b867416        2234  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+c2af1b9ce38e9a68c60d3a69c57622726d72e2aae854bd6a805f9bccee218db6        2210  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
 4543a3b0b1193fe5a151b3ae04f2c4b5875b1afcdaf88610ef4904c0a134abd5         455  BitCrypto/BitCrypto.PSBTCLI/CMakeLists.txt
 2972187d8c9162047959eb9f38656513d49b234ec0e7eabe29fa2cec40e97e19       12904  BitCrypto/BitCrypto.PSBTCLI/src/main.cpp
 d0c91641d3609926b9197e6cda79931238b4b423d8600ad30c83c5fbb9c8c491         762  BitCrypto/BitCrypto.CLI/CMakeLists.txt

--- a/MANIFEST_v2.5.0.txt
+++ b/MANIFEST_v2.5.0.txt
@@ -26,7 +26,7 @@ d0f1b66d172a3d6fb7a4db68b1f794a88dffb512b8caf0286c91ba8b76c09efd        1017  Bi
 e134c5e7ecacd36bb4cb054210a70abaf8461eedae707e641fc4998405bbcf5d        3546  BitCrypto/BitCrypto.WSCLI/src/main.cpp
 22cb673c5252d0dc81f0bc82f6b5f1651399139431e5092dd9a1c265ecfb91ed         289  BitCrypto/BitCrypto.RNG/CMakeLists.txt
 f55bb0e34a0d4f2d678a3f794661cc5ce7f133731adc76fd54df1b75555af481          16  BitCrypto/BitCrypto.RNG/src/unity.cpp
-5536075a88ed8a95b56cd485dfb4accf96ec47fc2ada6d6037e56453332329f0        1746  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+094389063a43e311605f0afd775b49571f602fa22ff7b65efd4fd8a6974f60f8        1765  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
 4543a3b0b1193fe5a151b3ae04f2c4b5875b1afcdaf88610ef4904c0a134abd5         455  BitCrypto/BitCrypto.PSBTCLI/CMakeLists.txt
 2972187d8c9162047959eb9f38656513d49b234ec0e7eabe29fa2cec40e97e19       12904  BitCrypto/BitCrypto.PSBTCLI/src/main.cpp
 d0c91641d3609926b9197e6cda79931238b4b423d8600ad30c83c5fbb9c8c491         762  BitCrypto/BitCrypto.CLI/CMakeLists.txt

--- a/MANIFEST_v2.5.0.txt
+++ b/MANIFEST_v2.5.0.txt
@@ -26,7 +26,7 @@ d0f1b66d172a3d6fb7a4db68b1f794a88dffb512b8caf0286c91ba8b76c09efd        1017  Bi
 e134c5e7ecacd36bb4cb054210a70abaf8461eedae707e641fc4998405bbcf5d        3546  BitCrypto/BitCrypto.WSCLI/src/main.cpp
 22cb673c5252d0dc81f0bc82f6b5f1651399139431e5092dd9a1c265ecfb91ed         289  BitCrypto/BitCrypto.RNG/CMakeLists.txt
 f55bb0e34a0d4f2d678a3f794661cc5ce7f133731adc76fd54df1b75555af481          16  BitCrypto/BitCrypto.RNG/src/unity.cpp
-7552a10da48a532bca8590e7fc39048f79edc486629a9b618baf8174e2bb923e        5645  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+109dda471eb17c51dedea3a52d729ac880c6275f4d5235197759cb20070332b4        5824  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
 4543a3b0b1193fe5a151b3ae04f2c4b5875b1afcdaf88610ef4904c0a134abd5         455  BitCrypto/BitCrypto.PSBTCLI/CMakeLists.txt
 2972187d8c9162047959eb9f38656513d49b234ec0e7eabe29fa2cec40e97e19       12904  BitCrypto/BitCrypto.PSBTCLI/src/main.cpp
 d0c91641d3609926b9197e6cda79931238b4b423d8600ad30c83c5fbb9c8c491         762  BitCrypto/BitCrypto.CLI/CMakeLists.txt

--- a/MANIFEST_v2.5.0.txt
+++ b/MANIFEST_v2.5.0.txt
@@ -26,7 +26,7 @@ d0f1b66d172a3d6fb7a4db68b1f794a88dffb512b8caf0286c91ba8b76c09efd        1017  Bi
 e134c5e7ecacd36bb4cb054210a70abaf8461eedae707e641fc4998405bbcf5d        3546  BitCrypto/BitCrypto.WSCLI/src/main.cpp
 22cb673c5252d0dc81f0bc82f6b5f1651399139431e5092dd9a1c265ecfb91ed         289  BitCrypto/BitCrypto.RNG/CMakeLists.txt
 f55bb0e34a0d4f2d678a3f794661cc5ce7f133731adc76fd54df1b75555af481          16  BitCrypto/BitCrypto.RNG/src/unity.cpp
-019db75005538da9667d3c23fd88e07fb4e7646bc1f8b9ecdd10edb69b60724e        3939  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+d5bddbc7228fd626120a21ddf600162d1480cad1dfee02f2f17f7a8fddb1b1ba        4625  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
 4543a3b0b1193fe5a151b3ae04f2c4b5875b1afcdaf88610ef4904c0a134abd5         455  BitCrypto/BitCrypto.PSBTCLI/CMakeLists.txt
 2972187d8c9162047959eb9f38656513d49b234ec0e7eabe29fa2cec40e97e19       12904  BitCrypto/BitCrypto.PSBTCLI/src/main.cpp
 d0c91641d3609926b9197e6cda79931238b4b423d8600ad30c83c5fbb9c8c491         762  BitCrypto/BitCrypto.CLI/CMakeLists.txt

--- a/MANIFEST_v2.5.0.txt
+++ b/MANIFEST_v2.5.0.txt
@@ -26,7 +26,7 @@ d0f1b66d172a3d6fb7a4db68b1f794a88dffb512b8caf0286c91ba8b76c09efd        1017  Bi
 e134c5e7ecacd36bb4cb054210a70abaf8461eedae707e641fc4998405bbcf5d        3546  BitCrypto/BitCrypto.WSCLI/src/main.cpp
 22cb673c5252d0dc81f0bc82f6b5f1651399139431e5092dd9a1c265ecfb91ed         289  BitCrypto/BitCrypto.RNG/CMakeLists.txt
 f55bb0e34a0d4f2d678a3f794661cc5ce7f133731adc76fd54df1b75555af481          16  BitCrypto/BitCrypto.RNG/src/unity.cpp
-dc40664a27b317f9625b92463e197586d431141b94fc70080e0ad9af60eaeff9        4933  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+7552a10da48a532bca8590e7fc39048f79edc486629a9b618baf8174e2bb923e        5645  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
 4543a3b0b1193fe5a151b3ae04f2c4b5875b1afcdaf88610ef4904c0a134abd5         455  BitCrypto/BitCrypto.PSBTCLI/CMakeLists.txt
 2972187d8c9162047959eb9f38656513d49b234ec0e7eabe29fa2cec40e97e19       12904  BitCrypto/BitCrypto.PSBTCLI/src/main.cpp
 d0c91641d3609926b9197e6cda79931238b4b423d8600ad30c83c5fbb9c8c491         762  BitCrypto/BitCrypto.CLI/CMakeLists.txt

--- a/MANIFEST_v2.5.0.txt
+++ b/MANIFEST_v2.5.0.txt
@@ -26,7 +26,7 @@ d0f1b66d172a3d6fb7a4db68b1f794a88dffb512b8caf0286c91ba8b76c09efd        1017  Bi
 e134c5e7ecacd36bb4cb054210a70abaf8461eedae707e641fc4998405bbcf5d        3546  BitCrypto/BitCrypto.WSCLI/src/main.cpp
 22cb673c5252d0dc81f0bc82f6b5f1651399139431e5092dd9a1c265ecfb91ed         289  BitCrypto/BitCrypto.RNG/CMakeLists.txt
 f55bb0e34a0d4f2d678a3f794661cc5ce7f133731adc76fd54df1b75555af481          16  BitCrypto/BitCrypto.RNG/src/unity.cpp
-90d2523bc1f127bdcac27707788d10ef23a8aeb513459b973109130096fb93e6        3078  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+4e80a75399f38b2819108007bc069d93cf0e7e47adbee822907da9d600825786        3191  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
 4543a3b0b1193fe5a151b3ae04f2c4b5875b1afcdaf88610ef4904c0a134abd5         455  BitCrypto/BitCrypto.PSBTCLI/CMakeLists.txt
 2972187d8c9162047959eb9f38656513d49b234ec0e7eabe29fa2cec40e97e19       12904  BitCrypto/BitCrypto.PSBTCLI/src/main.cpp
 d0c91641d3609926b9197e6cda79931238b4b423d8600ad30c83c5fbb9c8c491         762  BitCrypto/BitCrypto.CLI/CMakeLists.txt

--- a/MANIFEST_v2.5.0.txt
+++ b/MANIFEST_v2.5.0.txt
@@ -26,7 +26,7 @@ d0f1b66d172a3d6fb7a4db68b1f794a88dffb512b8caf0286c91ba8b76c09efd        1017  Bi
 e134c5e7ecacd36bb4cb054210a70abaf8461eedae707e641fc4998405bbcf5d        3546  BitCrypto/BitCrypto.WSCLI/src/main.cpp
 22cb673c5252d0dc81f0bc82f6b5f1651399139431e5092dd9a1c265ecfb91ed         289  BitCrypto/BitCrypto.RNG/CMakeLists.txt
 f55bb0e34a0d4f2d678a3f794661cc5ce7f133731adc76fd54df1b75555af481          16  BitCrypto/BitCrypto.RNG/src/unity.cpp
-547abc0a95419f1bcb864b352e35431730373dfcca737877a5c3e3a05a67b37a        2072  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+27f8a3f90151de3f763ef96371c0253ac2b93ef73dee73ca7757bba00c75acb4        2126  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
 4543a3b0b1193fe5a151b3ae04f2c4b5875b1afcdaf88610ef4904c0a134abd5         455  BitCrypto/BitCrypto.PSBTCLI/CMakeLists.txt
 2972187d8c9162047959eb9f38656513d49b234ec0e7eabe29fa2cec40e97e19       12904  BitCrypto/BitCrypto.PSBTCLI/src/main.cpp
 d0c91641d3609926b9197e6cda79931238b4b423d8600ad30c83c5fbb9c8c491         762  BitCrypto/BitCrypto.CLI/CMakeLists.txt

--- a/MANIFEST_v2.5.0.txt
+++ b/MANIFEST_v2.5.0.txt
@@ -26,7 +26,7 @@ d0f1b66d172a3d6fb7a4db68b1f794a88dffb512b8caf0286c91ba8b76c09efd        1017  Bi
 e134c5e7ecacd36bb4cb054210a70abaf8461eedae707e641fc4998405bbcf5d        3546  BitCrypto/BitCrypto.WSCLI/src/main.cpp
 22cb673c5252d0dc81f0bc82f6b5f1651399139431e5092dd9a1c265ecfb91ed         289  BitCrypto/BitCrypto.RNG/CMakeLists.txt
 f55bb0e34a0d4f2d678a3f794661cc5ce7f133731adc76fd54df1b75555af481          16  BitCrypto/BitCrypto.RNG/src/unity.cpp
-ee638a586209076961a789955059261f5ddbd051baf1abb23447ebb5a754c47e        2583  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+90d2523bc1f127bdcac27707788d10ef23a8aeb513459b973109130096fb93e6        3078  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
 4543a3b0b1193fe5a151b3ae04f2c4b5875b1afcdaf88610ef4904c0a134abd5         455  BitCrypto/BitCrypto.PSBTCLI/CMakeLists.txt
 2972187d8c9162047959eb9f38656513d49b234ec0e7eabe29fa2cec40e97e19       12904  BitCrypto/BitCrypto.PSBTCLI/src/main.cpp
 d0c91641d3609926b9197e6cda79931238b4b423d8600ad30c83c5fbb9c8c491         762  BitCrypto/BitCrypto.CLI/CMakeLists.txt

--- a/MANIFEST_v2.5.0.txt
+++ b/MANIFEST_v2.5.0.txt
@@ -26,7 +26,7 @@ d0f1b66d172a3d6fb7a4db68b1f794a88dffb512b8caf0286c91ba8b76c09efd        1017  Bi
 e134c5e7ecacd36bb4cb054210a70abaf8461eedae707e641fc4998405bbcf5d        3546  BitCrypto/BitCrypto.WSCLI/src/main.cpp
 22cb673c5252d0dc81f0bc82f6b5f1651399139431e5092dd9a1c265ecfb91ed         289  BitCrypto/BitCrypto.RNG/CMakeLists.txt
 f55bb0e34a0d4f2d678a3f794661cc5ce7f133731adc76fd54df1b75555af481          16  BitCrypto/BitCrypto.RNG/src/unity.cpp
-e32b6b0dfeee02a20c00156ad27f06e00937e5feb3836fb289bc17037c2d0bdb        1826  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+d3bf5c90cdcf302150957d1b789b18d95657eb6d460c096c4a693d2809d7a847        1867  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
 4543a3b0b1193fe5a151b3ae04f2c4b5875b1afcdaf88610ef4904c0a134abd5         455  BitCrypto/BitCrypto.PSBTCLI/CMakeLists.txt
 2972187d8c9162047959eb9f38656513d49b234ec0e7eabe29fa2cec40e97e19       12904  BitCrypto/BitCrypto.PSBTCLI/src/main.cpp
 d0c91641d3609926b9197e6cda79931238b4b423d8600ad30c83c5fbb9c8c491         762  BitCrypto/BitCrypto.CLI/CMakeLists.txt

--- a/MANIFEST_v2.5.0.txt
+++ b/MANIFEST_v2.5.0.txt
@@ -26,7 +26,7 @@ d0f1b66d172a3d6fb7a4db68b1f794a88dffb512b8caf0286c91ba8b76c09efd        1017  Bi
 e134c5e7ecacd36bb4cb054210a70abaf8461eedae707e641fc4998405bbcf5d        3546  BitCrypto/BitCrypto.WSCLI/src/main.cpp
 22cb673c5252d0dc81f0bc82f6b5f1651399139431e5092dd9a1c265ecfb91ed         289  BitCrypto/BitCrypto.RNG/CMakeLists.txt
 f55bb0e34a0d4f2d678a3f794661cc5ce7f133731adc76fd54df1b75555af481          16  BitCrypto/BitCrypto.RNG/src/unity.cpp
-109dda471eb17c51dedea3a52d729ac880c6275f4d5235197759cb20070332b4        5824  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+4f1dfa38313e2722f8876db18dcd602117fd8cdbb19abfda8c54377a308a6919        7375  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
 4543a3b0b1193fe5a151b3ae04f2c4b5875b1afcdaf88610ef4904c0a134abd5         455  BitCrypto/BitCrypto.PSBTCLI/CMakeLists.txt
 2972187d8c9162047959eb9f38656513d49b234ec0e7eabe29fa2cec40e97e19       12904  BitCrypto/BitCrypto.PSBTCLI/src/main.cpp
 d0c91641d3609926b9197e6cda79931238b4b423d8600ad30c83c5fbb9c8c491         762  BitCrypto/BitCrypto.CLI/CMakeLists.txt

--- a/MANIFEST_v2.5.0.txt
+++ b/MANIFEST_v2.5.0.txt
@@ -26,7 +26,7 @@ d0f1b66d172a3d6fb7a4db68b1f794a88dffb512b8caf0286c91ba8b76c09efd        1017  Bi
 e134c5e7ecacd36bb4cb054210a70abaf8461eedae707e641fc4998405bbcf5d        3546  BitCrypto/BitCrypto.WSCLI/src/main.cpp
 22cb673c5252d0dc81f0bc82f6b5f1651399139431e5092dd9a1c265ecfb91ed         289  BitCrypto/BitCrypto.RNG/CMakeLists.txt
 f55bb0e34a0d4f2d678a3f794661cc5ce7f133731adc76fd54df1b75555af481          16  BitCrypto/BitCrypto.RNG/src/unity.cpp
-9f76018bda4cd7530d382925a67402d6ba3261249d5be3f76a2005167a7e37b5        3900  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+019db75005538da9667d3c23fd88e07fb4e7646bc1f8b9ecdd10edb69b60724e        3939  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
 4543a3b0b1193fe5a151b3ae04f2c4b5875b1afcdaf88610ef4904c0a134abd5         455  BitCrypto/BitCrypto.PSBTCLI/CMakeLists.txt
 2972187d8c9162047959eb9f38656513d49b234ec0e7eabe29fa2cec40e97e19       12904  BitCrypto/BitCrypto.PSBTCLI/src/main.cpp
 d0c91641d3609926b9197e6cda79931238b4b423d8600ad30c83c5fbb9c8c491         762  BitCrypto/BitCrypto.CLI/CMakeLists.txt

--- a/MANIFEST_v2.5.0.txt
+++ b/MANIFEST_v2.5.0.txt
@@ -26,7 +26,7 @@ d0f1b66d172a3d6fb7a4db68b1f794a88dffb512b8caf0286c91ba8b76c09efd        1017  Bi
 e134c5e7ecacd36bb4cb054210a70abaf8461eedae707e641fc4998405bbcf5d        3546  BitCrypto/BitCrypto.WSCLI/src/main.cpp
 22cb673c5252d0dc81f0bc82f6b5f1651399139431e5092dd9a1c265ecfb91ed         289  BitCrypto/BitCrypto.RNG/CMakeLists.txt
 f55bb0e34a0d4f2d678a3f794661cc5ce7f133731adc76fd54df1b75555af481          16  BitCrypto/BitCrypto.RNG/src/unity.cpp
-639743caf6b15e88ddadaac1c3ce734a99c71d312955fa4e96a1fff9ee7168c9        1955  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+a77ffc5f26ea6344f409b164250da8eab540af03fef2257536c66edf4d4ca560        1956  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
 4543a3b0b1193fe5a151b3ae04f2c4b5875b1afcdaf88610ef4904c0a134abd5         455  BitCrypto/BitCrypto.PSBTCLI/CMakeLists.txt
 2972187d8c9162047959eb9f38656513d49b234ec0e7eabe29fa2cec40e97e19       12904  BitCrypto/BitCrypto.PSBTCLI/src/main.cpp
 d0c91641d3609926b9197e6cda79931238b4b423d8600ad30c83c5fbb9c8c491         762  BitCrypto/BitCrypto.CLI/CMakeLists.txt

--- a/MANIFEST_v2.5.0.txt
+++ b/MANIFEST_v2.5.0.txt
@@ -26,7 +26,7 @@ d0f1b66d172a3d6fb7a4db68b1f794a88dffb512b8caf0286c91ba8b76c09efd        1017  Bi
 e134c5e7ecacd36bb4cb054210a70abaf8461eedae707e641fc4998405bbcf5d        3546  BitCrypto/BitCrypto.WSCLI/src/main.cpp
 22cb673c5252d0dc81f0bc82f6b5f1651399139431e5092dd9a1c265ecfb91ed         289  BitCrypto/BitCrypto.RNG/CMakeLists.txt
 f55bb0e34a0d4f2d678a3f794661cc5ce7f133731adc76fd54df1b75555af481          16  BitCrypto/BitCrypto.RNG/src/unity.cpp
-a77ffc5f26ea6344f409b164250da8eab540af03fef2257536c66edf4d4ca560        1956  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+3ee4c86e75ee0d40d93e77fb98feb6408e422e6b57600491c6dfa6d1def62fd1        1961  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
 4543a3b0b1193fe5a151b3ae04f2c4b5875b1afcdaf88610ef4904c0a134abd5         455  BitCrypto/BitCrypto.PSBTCLI/CMakeLists.txt
 2972187d8c9162047959eb9f38656513d49b234ec0e7eabe29fa2cec40e97e19       12904  BitCrypto/BitCrypto.PSBTCLI/src/main.cpp
 d0c91641d3609926b9197e6cda79931238b4b423d8600ad30c83c5fbb9c8c491         762  BitCrypto/BitCrypto.CLI/CMakeLists.txt

--- a/MANIFEST_v2.5.0.txt
+++ b/MANIFEST_v2.5.0.txt
@@ -26,7 +26,7 @@ d0f1b66d172a3d6fb7a4db68b1f794a88dffb512b8caf0286c91ba8b76c09efd        1017  Bi
 e134c5e7ecacd36bb4cb054210a70abaf8461eedae707e641fc4998405bbcf5d        3546  BitCrypto/BitCrypto.WSCLI/src/main.cpp
 22cb673c5252d0dc81f0bc82f6b5f1651399139431e5092dd9a1c265ecfb91ed         289  BitCrypto/BitCrypto.RNG/CMakeLists.txt
 f55bb0e34a0d4f2d678a3f794661cc5ce7f133731adc76fd54df1b75555af481          16  BitCrypto/BitCrypto.RNG/src/unity.cpp
-188cf76fb76a65ca1954d941ffef523880562a7f9148c274ff1bf7263c54448a        1558  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+5536075a88ed8a95b56cd485dfb4accf96ec47fc2ada6d6037e56453332329f0        1746  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
 4543a3b0b1193fe5a151b3ae04f2c4b5875b1afcdaf88610ef4904c0a134abd5         455  BitCrypto/BitCrypto.PSBTCLI/CMakeLists.txt
 2972187d8c9162047959eb9f38656513d49b234ec0e7eabe29fa2cec40e97e19       12904  BitCrypto/BitCrypto.PSBTCLI/src/main.cpp
 d0c91641d3609926b9197e6cda79931238b4b423d8600ad30c83c5fbb9c8c491         762  BitCrypto/BitCrypto.CLI/CMakeLists.txt

--- a/MANIFEST_v2.5.0.txt
+++ b/MANIFEST_v2.5.0.txt
@@ -26,7 +26,7 @@ d0f1b66d172a3d6fb7a4db68b1f794a88dffb512b8caf0286c91ba8b76c09efd        1017  Bi
 e134c5e7ecacd36bb4cb054210a70abaf8461eedae707e641fc4998405bbcf5d        3546  BitCrypto/BitCrypto.WSCLI/src/main.cpp
 22cb673c5252d0dc81f0bc82f6b5f1651399139431e5092dd9a1c265ecfb91ed         289  BitCrypto/BitCrypto.RNG/CMakeLists.txt
 f55bb0e34a0d4f2d678a3f794661cc5ce7f133731adc76fd54df1b75555af481          16  BitCrypto/BitCrypto.RNG/src/unity.cpp
-094389063a43e311605f0afd775b49571f602fa22ff7b65efd4fd8a6974f60f8        1765  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+e32b6b0dfeee02a20c00156ad27f06e00937e5feb3836fb289bc17037c2d0bdb        1826  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
 4543a3b0b1193fe5a151b3ae04f2c4b5875b1afcdaf88610ef4904c0a134abd5         455  BitCrypto/BitCrypto.PSBTCLI/CMakeLists.txt
 2972187d8c9162047959eb9f38656513d49b234ec0e7eabe29fa2cec40e97e19       12904  BitCrypto/BitCrypto.PSBTCLI/src/main.cpp
 d0c91641d3609926b9197e6cda79931238b4b423d8600ad30c83c5fbb9c8c491         762  BitCrypto/BitCrypto.CLI/CMakeLists.txt

--- a/MANIFEST_v2.5.0.txt
+++ b/MANIFEST_v2.5.0.txt
@@ -26,7 +26,7 @@ d0f1b66d172a3d6fb7a4db68b1f794a88dffb512b8caf0286c91ba8b76c09efd        1017  Bi
 e134c5e7ecacd36bb4cb054210a70abaf8461eedae707e641fc4998405bbcf5d        3546  BitCrypto/BitCrypto.WSCLI/src/main.cpp
 22cb673c5252d0dc81f0bc82f6b5f1651399139431e5092dd9a1c265ecfb91ed         289  BitCrypto/BitCrypto.RNG/CMakeLists.txt
 f55bb0e34a0d4f2d678a3f794661cc5ce7f133731adc76fd54df1b75555af481          16  BitCrypto/BitCrypto.RNG/src/unity.cpp
-4f1dfa38313e2722f8876db18dcd602117fd8cdbb19abfda8c54377a308a6919        7375  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+109b125be5223c4d5c82fd53689835c1a44c26b91c3e1350c00cd3efda0fb466        8023  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
 4543a3b0b1193fe5a151b3ae04f2c4b5875b1afcdaf88610ef4904c0a134abd5         455  BitCrypto/BitCrypto.PSBTCLI/CMakeLists.txt
 2972187d8c9162047959eb9f38656513d49b234ec0e7eabe29fa2cec40e97e19       12904  BitCrypto/BitCrypto.PSBTCLI/src/main.cpp
 d0c91641d3609926b9197e6cda79931238b4b423d8600ad30c83c5fbb9c8c491         762  BitCrypto/BitCrypto.CLI/CMakeLists.txt

--- a/MANIFEST_v2.5.0.txt
+++ b/MANIFEST_v2.5.0.txt
@@ -26,7 +26,7 @@ d0f1b66d172a3d6fb7a4db68b1f794a88dffb512b8caf0286c91ba8b76c09efd        1017  Bi
 e134c5e7ecacd36bb4cb054210a70abaf8461eedae707e641fc4998405bbcf5d        3546  BitCrypto/BitCrypto.WSCLI/src/main.cpp
 22cb673c5252d0dc81f0bc82f6b5f1651399139431e5092dd9a1c265ecfb91ed         289  BitCrypto/BitCrypto.RNG/CMakeLists.txt
 f55bb0e34a0d4f2d678a3f794661cc5ce7f133731adc76fd54df1b75555af481          16  BitCrypto/BitCrypto.RNG/src/unity.cpp
-d3bf5c90cdcf302150957d1b789b18d95657eb6d460c096c4a693d2809d7a847        1867  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+e7aa921b285112a48db07e46d5db41c0df01cc298a5f316236d83cbf4e066f18        1919  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
 4543a3b0b1193fe5a151b3ae04f2c4b5875b1afcdaf88610ef4904c0a134abd5         455  BitCrypto/BitCrypto.PSBTCLI/CMakeLists.txt
 2972187d8c9162047959eb9f38656513d49b234ec0e7eabe29fa2cec40e97e19       12904  BitCrypto/BitCrypto.PSBTCLI/src/main.cpp
 d0c91641d3609926b9197e6cda79931238b4b423d8600ad30c83c5fbb9c8c491         762  BitCrypto/BitCrypto.CLI/CMakeLists.txt

--- a/MANIFEST_v2.5.0.txt
+++ b/MANIFEST_v2.5.0.txt
@@ -26,7 +26,7 @@ d0f1b66d172a3d6fb7a4db68b1f794a88dffb512b8caf0286c91ba8b76c09efd        1017  Bi
 e134c5e7ecacd36bb4cb054210a70abaf8461eedae707e641fc4998405bbcf5d        3546  BitCrypto/BitCrypto.WSCLI/src/main.cpp
 22cb673c5252d0dc81f0bc82f6b5f1651399139431e5092dd9a1c265ecfb91ed         289  BitCrypto/BitCrypto.RNG/CMakeLists.txt
 f55bb0e34a0d4f2d678a3f794661cc5ce7f133731adc76fd54df1b75555af481          16  BitCrypto/BitCrypto.RNG/src/unity.cpp
-1021d4402954130f6ea6064776766498b9f83b7dd5c498175238c119b64f861b        1384  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+188cf76fb76a65ca1954d941ffef523880562a7f9148c274ff1bf7263c54448a        1558  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
 4543a3b0b1193fe5a151b3ae04f2c4b5875b1afcdaf88610ef4904c0a134abd5         455  BitCrypto/BitCrypto.PSBTCLI/CMakeLists.txt
 2972187d8c9162047959eb9f38656513d49b234ec0e7eabe29fa2cec40e97e19       12904  BitCrypto/BitCrypto.PSBTCLI/src/main.cpp
 d0c91641d3609926b9197e6cda79931238b4b423d8600ad30c83c5fbb9c8c491         762  BitCrypto/BitCrypto.CLI/CMakeLists.txt

--- a/MANIFEST_v2.5.0.txt
+++ b/MANIFEST_v2.5.0.txt
@@ -26,7 +26,7 @@ d0f1b66d172a3d6fb7a4db68b1f794a88dffb512b8caf0286c91ba8b76c09efd        1017  Bi
 e134c5e7ecacd36bb4cb054210a70abaf8461eedae707e641fc4998405bbcf5d        3546  BitCrypto/BitCrypto.WSCLI/src/main.cpp
 22cb673c5252d0dc81f0bc82f6b5f1651399139431e5092dd9a1c265ecfb91ed         289  BitCrypto/BitCrypto.RNG/CMakeLists.txt
 f55bb0e34a0d4f2d678a3f794661cc5ce7f133731adc76fd54df1b75555af481          16  BitCrypto/BitCrypto.RNG/src/unity.cpp
-109b125be5223c4d5c82fd53689835c1a44c26b91c3e1350c00cd3efda0fb466        8023  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+ef9103b367791aabec92d924bcb19d6b3b6b24d70403748a15b27bedbfc6c26b        9373  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
 4543a3b0b1193fe5a151b3ae04f2c4b5875b1afcdaf88610ef4904c0a134abd5         455  BitCrypto/BitCrypto.PSBTCLI/CMakeLists.txt
 2972187d8c9162047959eb9f38656513d49b234ec0e7eabe29fa2cec40e97e19       12904  BitCrypto/BitCrypto.PSBTCLI/src/main.cpp
 d0c91641d3609926b9197e6cda79931238b4b423d8600ad30c83c5fbb9c8c491         762  BitCrypto/BitCrypto.CLI/CMakeLists.txt

--- a/MANIFEST_v2.5.0.txt
+++ b/MANIFEST_v2.5.0.txt
@@ -26,7 +26,7 @@ d0f1b66d172a3d6fb7a4db68b1f794a88dffb512b8caf0286c91ba8b76c09efd        1017  Bi
 e134c5e7ecacd36bb4cb054210a70abaf8461eedae707e641fc4998405bbcf5d        3546  BitCrypto/BitCrypto.WSCLI/src/main.cpp
 22cb673c5252d0dc81f0bc82f6b5f1651399139431e5092dd9a1c265ecfb91ed         289  BitCrypto/BitCrypto.RNG/CMakeLists.txt
 f55bb0e34a0d4f2d678a3f794661cc5ce7f133731adc76fd54df1b75555af481          16  BitCrypto/BitCrypto.RNG/src/unity.cpp
-c2af1b9ce38e9a68c60d3a69c57622726d72e2aae854bd6a805f9bccee218db6        2210  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+ee638a586209076961a789955059261f5ddbd051baf1abb23447ebb5a754c47e        2583  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
 4543a3b0b1193fe5a151b3ae04f2c4b5875b1afcdaf88610ef4904c0a134abd5         455  BitCrypto/BitCrypto.PSBTCLI/CMakeLists.txt
 2972187d8c9162047959eb9f38656513d49b234ec0e7eabe29fa2cec40e97e19       12904  BitCrypto/BitCrypto.PSBTCLI/src/main.cpp
 d0c91641d3609926b9197e6cda79931238b4b423d8600ad30c83c5fbb9c8c491         762  BitCrypto/BitCrypto.CLI/CMakeLists.txt

--- a/MANIFEST_v2.5.0.txt
+++ b/MANIFEST_v2.5.0.txt
@@ -26,7 +26,7 @@ d0f1b66d172a3d6fb7a4db68b1f794a88dffb512b8caf0286c91ba8b76c09efd        1017  Bi
 e134c5e7ecacd36bb4cb054210a70abaf8461eedae707e641fc4998405bbcf5d        3546  BitCrypto/BitCrypto.WSCLI/src/main.cpp
 22cb673c5252d0dc81f0bc82f6b5f1651399139431e5092dd9a1c265ecfb91ed         289  BitCrypto/BitCrypto.RNG/CMakeLists.txt
 f55bb0e34a0d4f2d678a3f794661cc5ce7f133731adc76fd54df1b75555af481          16  BitCrypto/BitCrypto.RNG/src/unity.cpp
-e16dfc04ed85d99bf4f8a0d723f7a548ccbb64201bacc6779184da3c81781d70         585  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
+1021d4402954130f6ea6064776766498b9f83b7dd5c498175238c119b64f861b        1384  BitCrypto/BitCrypto.RNG/include/bitcrypto/rng/rng.h
 4543a3b0b1193fe5a151b3ae04f2c4b5875b1afcdaf88610ef4904c0a134abd5         455  BitCrypto/BitCrypto.PSBTCLI/CMakeLists.txt
 2972187d8c9162047959eb9f38656513d49b234ec0e7eabe29fa2cec40e97e19       12904  BitCrypto/BitCrypto.PSBTCLI/src/main.cpp
 d0c91641d3609926b9197e6cda79931238b4b423d8600ad30c83c5fbb9c8c491         762  BitCrypto/BitCrypto.CLI/CMakeLists.txt


### PR DESCRIPTION
## Summary
- preenche o buffer de aleatoriedade em Unix usando getrandom() ou leitura de /dev/urandom
- adiciona documentação da dependência de entropia do sistema

## Testing
- `python tools/guardrails/check_constant_time_heuristic.py`
- `python tools/guardrails/check_no_external_deps.py`
- `python tools/guardrails/check_features.py`
- `python tools/guardrails/check_stubs.py`
- `python tools/guardrails/check_manifest.py`
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68c5f45a1e688333ac2bfec0e40fec60